### PR TITLE
Implement option to selectively disable specific agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ repositories:
 - `prompt`: Primary role and responsibilities
 - `github_token`: GitHub personal access token for this agent
 - `github_user`: GitHub username associated with the token (required for security validation)
+- `enabled`: Enable/disable agent without removing configuration (optional, defaults to true)
 - `settings`: Agent-specific overrides for global settings (optional)
   - `docker_image`: Custom Docker image for this agent
   - `docker_user`: Custom user for this agent
@@ -214,6 +215,7 @@ autoteam init      # Create sample autoteam.yaml
 autoteam generate  # Generate compose.yaml from config
 autoteam up        # Generate and start containers
 autoteam down      # Stop containers
+autoteam agents     # List all agents and their states
 ```
 
 All generated files are organized in the `.autoteam/` directory for better project organization.
@@ -246,6 +248,33 @@ Directory structure uses normalized names:
 └── api_agent_1/
     └── codebase/
 ```
+
+### Disabling Agents
+
+You can temporarily disable agents without removing their configuration:
+
+```yaml
+agents:
+  - name: "developer"
+    prompt: "You are a developer agent"
+    github_token: "ghp_token1"
+    github_user: "dev-user"
+    enabled: true  # Agent is active (default)
+  
+  - name: "reviewer"
+    prompt: "You are a code reviewer"
+    github_token: "ghp_token2"
+    github_user: "reviewer-user"
+    enabled: false  # Agent is disabled - won't be deployed
+```
+
+Benefits:
+- Keep agent configurations for future use
+- Temporarily reduce resource usage
+- Test with specific agent combinations
+- Preserve tokens and settings when not actively needed
+
+Use `autoteam agents` to list all agents and their states.
 
 ## Architecture
 

--- a/examples/disabled-agent.yaml
+++ b/examples/disabled-agent.yaml
@@ -1,0 +1,46 @@
+# Example configuration with a disabled agent
+# This shows how to temporarily disable agents without removing their configuration
+
+repositories:
+  include:
+    - "myorg/main-project"
+    - "myorg/api-service"
+
+agents:
+  # Active developer agent
+  - name: "Developer"
+    prompt: |
+      You are a developer agent responsible for implementing features and fixing bugs.
+      Focus on writing clean, maintainable code with proper tests.
+    github_token: "${DEVELOPER_TOKEN}"
+    github_user: "dev-user"
+    enabled: true  # Explicitly enabled (this is the default)
+
+  # Temporarily disabled reviewer agent
+  - name: "Code Reviewer"
+    prompt: |
+      You are a code reviewer focused on code quality, best practices, and security.
+      Provide constructive feedback to improve code maintainability.
+    github_token: "${REVIEWER_TOKEN}"
+    github_user: "reviewer-user"
+    enabled: false  # This agent won't be deployed
+
+  # Another active agent
+  - name: "DevOps Engineer"
+    prompt: |
+      You are a DevOps engineer responsible for CI/CD, infrastructure, and deployment.
+      Focus on automation and reliability.
+    github_token: "${DEVOPS_TOKEN}"
+    github_user: "devops-user"
+    # 'enabled' not specified, defaults to true
+
+settings:
+  service:
+    image: "node:18.17.1"
+    user: "developer"
+  check_interval: 60
+  team_name: "my-team"
+  install_deps: true
+  common_prompt: |
+    Always follow the project's coding standards and best practices.
+    Write clear commit messages and document your changes.

--- a/internal/config/testdata/with_disabled_agents.yaml
+++ b/internal/config/testdata/with_disabled_agents.yaml
@@ -1,0 +1,28 @@
+repositories:
+  include:
+    - "owner/test-repo"
+
+agents:
+  - name: "dev1"
+    prompt: "You are a developer agent"
+    github_token: "DEV1_TOKEN"
+    github_user: "dev-user"
+    enabled: true
+  - name: "dev2"
+    prompt: "You are another developer agent"
+    github_token: "DEV2_TOKEN"
+    github_user: "dev-user2"
+    enabled: false
+  - name: "arch1"
+    prompt: "You are an architect agent"
+    github_token: "ARCH1_TOKEN"
+    github_user: "arch-user"
+    # enabled not set, defaults to true
+
+settings:
+  service:
+    image: "node:18.17.1"
+    user: "developer"
+  check_interval: 60
+  team_name: "test-team"
+  install_deps: true

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -56,8 +56,8 @@ func (g *Generator) generateComposeYAML(cfg *config.Config) error {
 		Services: make(map[string]interface{}),
 	}
 
-	// Get agents with their effective settings
-	agentsWithSettings := cfg.GetAllAgentsWithEffectiveSettings()
+	// Get only enabled agents with their effective settings
+	agentsWithSettings := cfg.GetEnabledAgentsWithEffectiveSettings()
 
 	for _, agentWithSettings := range agentsWithSettings {
 		agent := agentWithSettings.Agent
@@ -205,6 +205,10 @@ Supported platforms:
 
 func (g *Generator) createAgentDirectories(cfg *config.Config) error {
 	for _, agent := range cfg.Agents {
+		// Skip disabled agents
+		if !agent.IsEnabled() {
+			continue
+		}
 		normalizedName := agent.GetNormalizedName()
 		if err := g.fileOps.CreateAgentDirectoryStructure(normalizedName); err != nil {
 			return fmt.Errorf("failed to create directory structure for agent %s (normalized: %s): %w", agent.Name, normalizedName, err)


### PR DESCRIPTION
## Summary
- Adds the ability to selectively disable agents in the autoteam.yaml configuration
- Disabled agents are excluded from the generated compose.yaml file
- Implements new CLI command to view agent states

## Changes
1. **Configuration Enhancement**:
   - Added `enabled` field to Agent struct (defaults to true)
   - Updated validation to ensure at least one agent is enabled
   - Only validate required fields for enabled agents

2. **Generation Updates**:
   - Filter disabled agents during compose generation
   - Skip directory creation for disabled agents
   - Update collaborators list to only show enabled agents

3. **CLI Enhancement**:
   - Added `autoteam agents` command to list all agents and their states
   - Shows enabled/disabled status and summary counts

4. **Documentation & Testing**:
   - Updated README with configuration documentation
   - Added example configuration file with disabled agent
   - Comprehensive test coverage for disabled agent functionality

## Test plan
- [x] All existing tests pass
- [x] New tests for disabled agent functionality pass
- [x] Manual testing with disabled agents in config
- [x] Verified disabled agents are excluded from compose.yaml
- [x] Tested `autoteam agents` command

Closes #1