### PR TITLE
Fix release workflow: build dashboard before running tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,16 @@ jobs:
     - name: Download dependencies
       run: make mod-tidy
     
+    - name: Set up Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+        cache: 'npm'
+        cache-dependency-path: dashboard/package-lock.json
+    
+    - name: Build dashboard for tests
+      run: make dashboard-ui
+    
     - name: Run full test suite
       run: make test test-race
     


### PR DESCRIPTION
## Summary
- Fix dashboard test failures in release workflow by building dashboard before running tests
- Add Node.js setup and `make dashboard-ui` step to release workflow
- This matches the successful CI workflow pattern that builds dashboard first

## Problem
The release workflow was failing with dashboard server tests returning 500 instead of 200:
- `TestHandleStatic` tests expect embedded dashboard files (index.html, assets) to be present
- Release workflow was running `make test` without building dashboard first  
- This caused the embedded filesystem to be empty, leading to server errors

## Solution
- Add Node.js setup step before tests
- Run `make dashboard-ui` to build and embed dashboard files
- Ensures dashboard static files are available for tests
- Matches the working CI workflow structure

## Test Plan
- [x] Local tests pass with dashboard built
- [x] Dashboard tests specifically pass: `autoteam/internal/dashboard 0.303s`
- [ ] Release workflow will now build dashboard before tests

This should resolve the release action failures mentioned in the GitHub issue.