### PR TITLE
Fix release workflow: also build dashboard before creating release pa…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,6 +86,16 @@ jobs:
     - name: Download dependencies
       run: make mod-tidy
     
+    - name: Set up Node.js for dashboard
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+        cache: 'npm'
+        cache-dependency-path: dashboard/package-lock.json
+    
+    - name: Build dashboard for release
+      run: make dashboard-ui
+    
     - name: Create release packages
       run: make release
     


### PR DESCRIPTION
…ckages

- Build dashboard in both Pre-release Tests AND Build Release Binaries steps
- The 'make release' target includes 'test' which also needs dashboard files
- Ensures embedded static files are available for all test runs in release process
- Addresses dashboard test failures in Build Release Binaries step